### PR TITLE
Add Alpha

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "purescript-canvas": "~0.3.1",
     "purescript-lists": "~0.7.1",
-    "purescript-math": "~0.2.0"
+    "purescript-math": "~0.2.0",
+    "purescript-integers": "~0.2.1"
   }
 }

--- a/src/Graphics/Drawing/Color.js
+++ b/src/Graphics/Drawing/Color.js
@@ -1,9 +1,0 @@
-"use strict";
-
-// module Graphics.Drawing.Color
-
-exports.byteToHex = function(n) {
-    
-    var s = (n = Math.min(255, Math.max(n, 0)) | 0).toString(16);
-    return n >= 16 ? s : "0" + s;
-};

--- a/src/Graphics/Drawing/Color.purs
+++ b/src/Graphics/Drawing/Color.purs
@@ -1,32 +1,33 @@
 -- | This module defines preset colors, and functions for creating colors.
 
-module Graphics.Drawing.Color 
+module Graphics.Drawing.Color
   ( Color()
-  
+
   , colorString
-  
+
   , rgb
+  , rgba
   , hsl
-  
+
   , lighten
   , darken
-  
-  , white	
-  , silver	
-  , gray	
-  , black	
-  , red	    
-  , maroon	
-  , yellow	
-  , olive	
-  , lime	
-  , green	
-  , aqua	
-  , teal	
-  , blue	
-  , navy	
-  , fuchsia	
-  , purple	
+
+  , white
+  , silver
+  , gray
+  , black
+  , red
+  , maroon
+  , yellow
+  , olive
+  , lime
+  , green
+  , aqua
+  , teal
+  , blue
+  , navy
+  , fuchsia
+  , purple
   ) where
 
 import Prelude
@@ -34,16 +35,21 @@ import Prelude
 import Math
 
 -- | Colors.
-data Color = Color Number Number Number
+data Color = Color Number Number Number Number
 
 instance eqColor :: Eq Color where
-  eq (Color r g b) (Color r' g' b') = r == r'
-                                   && g == g'
-                                   && b == b'
+  eq (Color r g b a) (Color r' g' b' a') = r == r'
+                                        && g == g'
+                                        && b == b'
+                                        && a == a'
 
 -- | Create a `Color` from RGB values between 0.0 and 255.0.
 rgb :: Number -> Number -> Number -> Color
-rgb = Color
+rgb r g b = Color r g b 1.0
+
+-- | Create a `Color` from RGBA values between 0.0 and 255.0 (rgb), 0.0 and 1.0 (a)
+rgba :: Number -> Number -> Number -> Number -> Color
+rgba = Color
 
 -- | Create a `Color` from hue (0.0-360.0), saturation (0.0-1) and lightness (0.0-1) values.
 hsl :: Number -> Number -> Number -> Color
@@ -61,24 +67,22 @@ hsl h s l = rgb (255.0 * (rgb1.r + m))
        | 3.0 <= h' && h' < 4.0 = { r: 0.0, g: x  , b: chr }
        | 4.0 <= h' && h' < 5.0 = { r: x  , g: 0.0, b: chr }
        | otherwise             = { r: chr, g: 0.0, b: x   }
-  
+
 -- | Lighten a color by the specified amount between 0 and 1.
 lighten :: Number -> Color -> Color
-lighten l (Color r g b) = Color (interp r) (interp g) (interp b)
+lighten l (Color r g b a) = Color (interp r) (interp g) (interp b) a
   where
   interp c = 255.0 * l + c * (1.0 - l)
- 
+
 -- | Darken a color by the specified amount between 0 and 1.
 darken :: Number -> Color -> Color
-darken d (Color r g b) = Color (interp r) (interp g) (interp b)
+darken d (Color r g b a) = Color (interp r) (interp g) (interp b) a
   where
   interp c = c * (1.0 - d)
 
-foreign import byteToHex :: Number -> String
-
 -- | Render a color as a HTML color string.
 colorString :: Color -> String
-colorString (Color r g b) = "#" <> byteToHex r <> byteToHex g <> byteToHex b
+colorString (Color r g b a) = "rgba(" <> show r <> "," <> show g <> "," <> show b <> "," <> show a <> ")"
 
 white :: Color
 white = rgb 255.0 255.0 255.0

--- a/src/Graphics/Drawing/Color.purs
+++ b/src/Graphics/Drawing/Color.purs
@@ -33,6 +33,7 @@ module Graphics.Drawing.Color
 import Prelude
 
 import Math
+import qualified Data.Int as I
 
 -- | Colors.
 data Color = Color Number Number Number Number
@@ -82,7 +83,7 @@ darken d (Color r g b a) = Color (interp r) (interp g) (interp b) a
 
 -- | Render a color as a HTML color string.
 colorString :: Color -> String
-colorString (Color r g b a) = "rgba(" <> show r <> "," <> show g <> "," <> show b <> "," <> show a <> ")"
+colorString (Color r g b a) = "rgba(" <> show (I.floor r) <> "," <> show (I.floor g) <> "," <> show (I.floor b) <> "," <> show a <> ")"
 
 white :: Color
 white = rgb 255.0 255.0 255.0


### PR DESCRIPTION
It would be cool to have something along the lines of this. For a project, we require to draw over a background image of the canvas. The alpha channel would allow us to do so. 

Adjusting the test/Main.purs from `black` to `(rgba 255.0 0.0 0.0 0.1)` would result in something like this: 

![image](https://cloud.githubusercontent.com/assets/294174/11866682/e34e6e36-a4ac-11e5-8030-bac59c5d8427.png)
