### PR TITLE
Fix documentation on circle and arc parameters

### DIFF
--- a/src/Graphics/Drawing.purs
+++ b/src/Graphics/Drawing.purs
@@ -63,12 +63,12 @@ closed = Path true <<< fromFoldable
 rectangle :: Number -> Number -> Number -> Number -> Shape
 rectangle x y width height = Rectangle { x, y, width, height }
 
--- | Create a circle from the left, top and radius parameters.
+-- | Create a circle from the center-x, center-y and radius parameters.
 circle :: Number -> Number -> Number -> Shape
 circle x y = arc x y 0.0 (pi * 2.0)
 
--- | Create a circular arc from the left, top, start angle, end angle and
--- | radius parameters.
+-- | Create a circular arc from the center-x, center-y, start angle, end angle
+-- | and radius parameters.
 arc :: Number -> Number -> Number -> Number -> Number -> Shape
 arc x y start end radius = Arc { x, y, start, end, radius }
 


### PR DESCRIPTION
Both methods claimed to receive left and top as parameters, while they really used the parameters as center-x and center-y.